### PR TITLE
Changes to dates of sexuality education submission dates

### DIFF
--- a/_departments/CCE/Sexuality Education.md
+++ b/_departments/CCE/Sexuality Education.md
@@ -256,7 +256,8 @@ programmes by MOE-approved external providers.</p>
 <p>9.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Parents who wish to opt their children
 out of the Sexuality Education lessons need to complete an opt-out form.
 This form is accessible @ <a href="https://form.gov.sg/67918d223943ec900898c845" rel="noopener noreferrer nofollow" target="_blank"><u>https://form.gov.sg/67918d223943ec900898c845</u></a>.
-The completed opt-out form is to be submitted by 21 Feb 2025.</p>
+The completed opt-out form is to be submitted by 21 Feb 2025 (P5) and 10
+Oct 2025 (P6).</p>
 <p>10.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Parents can contact the school at (6267
 9234 or wgps@moe.edu.sg) for discussion or to seek clarification about
 the school’s Sexuality Education programme.</p>


### PR DESCRIPTION
New input: "The completed opt-out form is to be submitted by 21 Feb 2025 (P5) and 10 Oct 2025 (P6)."